### PR TITLE
Maxpool

### DIFF
--- a/examples/applications/bernoulli/conv_rbm_classification.py
+++ b/examples/applications/bernoulli/conv_rbm_classification.py
@@ -47,10 +47,14 @@ model = ConvRBM(
 model.fit(train, batch_size=batch_size, epochs=5)
 
 # Creating the Fully Connected layer to append on top of RBM
+h1 = model.hidden_shape[0]
+h2 = model.hidden_shape[1]
+nf = model.n_filters
+
 if model.maxpooling:
-    input_fc = n_filters * (model.hidden_shape[0] * model.hidden_shape[1])//2
+    input_fc = nf * (h1//2 + 1) * (h2//2 + 1)
 else:
-    input_fc = n_filters * model.hidden_shape[0] * model.hidden_shape[1]
+    input_fc = nf * h1 * h2
 fc = nn.Linear(input_fc , n_classes)
 
 # Check if model uses GPU

--- a/examples/applications/deep/conv_dbn_classification.py
+++ b/examples/applications/deep/conv_dbn_classification.py
@@ -32,7 +32,7 @@ model = ConvDBN(
     learning_rate=(0.0001, 0.00001),
     momentum=(0, 0),
     decay=(0, 0),
-    maxpooling=(True, True),
+    maxpooling=(False, True),
     use_gpu=True,
 )
 
@@ -40,6 +40,7 @@ batch_size = 128
 n_classes = 10
 fine_tune_epochs = 10
 epochs = (1, 1)
+
 # Training a ConvDBN
 model.fit(train, batch_size=batch_size, epochs=epochs)
 
@@ -49,19 +50,17 @@ model.fit(train, batch_size=batch_size, epochs=epochs)
 # Saving model
 torch.save(model, "model.pth")
 
-# Creating the Fully Connected layer to append on top of RBM
+# Creating the Fully Connected layer to append on top of DBN
 h1 = model.models[len(model.models)-1].hidden_shape[0]
 h2 = model.models[len(model.models)-1].hidden_shape[1]
 nf = model.models[len(model.models)-1].n_filters
 
 if model.models[len(model.models)-1].maxpooling:
     input_fc = nf * (h1//2 + 1) * (h2//2 + 1)
-    #input_fc = nf * (h1//2) * (h2//2)
 else:
-    input_fc = model.models[len(model.models)-1].n_filters * model.models[len(model.models)-1].hidden_shape[0] * model.models[len(model.models)-1].hidden_shape[1]
+    input_fc = nf * h1 * h2
 fc = nn.Linear(input_fc , n_classes)
 
-print(input_fc)
 # Check if model uses GPU
 if model.device == "cuda":
     # If yes, put fully-connected on GPU

--- a/examples/applications/deep/conv_dbn_classification.py
+++ b/examples/applications/deep/conv_dbn_classification.py
@@ -1,58 +1,67 @@
 import torch
+import torchvision
 import torch.nn as nn
 import torch.optim as optim
-import torchvision
+
 from torch.utils.data import DataLoader
 from tqdm import tqdm
+from learnergy.models.deep import ConvDBN
 
-from learnergy.models.gaussian import GaussianConvRBM
-
-# Defining some input variables
-v_shape = 32
-n_filters = 16
-f_shape = 5
-n_channels = 3
-batch_size = 100
-n_classes = 10
-fine_tune_epochs = 10
-
-# Creating training and validation/testing dataset
-train = torchvision.datasets.CIFAR10(
+# Creating training and testing dataset
+train = torchvision.datasets.MNIST(
     root="./data",
     train=True,
     download=True,
     transform=torchvision.transforms.ToTensor(),
 )
-test = torchvision.datasets.CIFAR10(
+test = torchvision.datasets.MNIST(
     root="./data",
     train=False,
     download=True,
     transform=torchvision.transforms.ToTensor(),
 )
 
-# Creating a GaussianConvRBM
-model = GaussianConvRBM(
-    visible_shape=(v_shape, v_shape),
-    filter_shape=(f_shape, f_shape),
-    n_filters=n_filters,
-    n_channels=n_channels,
-    learning_rate=0.00001,
-    momentum=0.5,
-    decay=0,
-    maxpooling=True,
+# Creating a ConvDBN
+model = ConvDBN(
+    model="gaussian",
+    visible_shape=(28, 28),
+    filter_shape=((5, 5), (5, 5)),
+    n_filters=(32, 32),
+    steps=(1, 1),
+    n_channels=1,
+    learning_rate=(0.0001, 0.00001),
+    momentum=(0, 0),
+    decay=(0, 0),
+    maxpooling=(True, True),
     use_gpu=True,
 )
 
-# Training a GaussianConvRBM
-model.fit(train, batch_size=batch_size, epochs=5)
+batch_size = 128
+n_classes = 10
+fine_tune_epochs = 10
+epochs = (1, 1)
+# Training a ConvDBN
+model.fit(train, batch_size=batch_size, epochs=epochs)
+
+# Reconstructing test set
+#rec_mse, v = model.reconstruct(test)
+
+# Saving model
+torch.save(model, "model.pth")
 
 # Creating the Fully Connected layer to append on top of RBM
-if model.maxpooling:
-    input_fc = n_filters * (model.hidden_shape[0] * model.hidden_shape[1])//2
+h1 = model.models[len(model.models)-1].hidden_shape[0]
+h2 = model.models[len(model.models)-1].hidden_shape[1]
+nf = model.models[len(model.models)-1].n_filters
+
+if model.models[len(model.models)-1].maxpooling:
+    input_fc = nf * (h1//2 + 1) * (h2//2 + 1)
+    #input_fc = nf * (h1//2) * (h2//2)
 else:
-    input_fc = n_filters * model.hidden_shape[0] * model.hidden_shape[1]
+    input_fc = model.models[len(model.models)-1].n_filters * model.models[len(model.models)-1].hidden_shape[0] * model.models[len(model.models)-1].hidden_shape[1]
 fc = nn.Linear(input_fc , n_classes)
 
+print(input_fc)
 # Check if model uses GPU
 if model.device == "cuda":
     # If yes, put fully-connected on GPU
@@ -63,12 +72,13 @@ criterion = nn.CrossEntropyLoss()
 
 # Creating the optimzers
 optimizer = [
-    optim.Adam(model.parameters(), lr=0.0001),
+    optim.Adam(model.models[0].parameters(), lr=0.0001),
+    optim.Adam(model.models[1].parameters(), lr=0.0001),
     optim.Adam(fc.parameters(), lr=0.001),
 ]
 
 # Creating training and validation batches
-train_batch = DataLoader(train, batch_size=batch_size, shuffle=False, num_workers=0)
+train_batch = DataLoader(train, batch_size=batch_size, shuffle=True, num_workers=0)
 val_batch = DataLoader(test, batch_size=10000, shuffle=False, num_workers=0)
 
 # For amount of fine-tuning epochs
@@ -93,7 +103,7 @@ for e in range(fine_tune_epochs):
 
         # Passing the batch down the model
         y = model(x_batch)
-
+        
         # Reshaping the outputs
         y = y.reshape(
             x_batch.size(0), input_fc)
@@ -125,7 +135,7 @@ for e in range(fine_tune_epochs):
 
         # Passing the batch down the model
         y = model(x_batch)
-
+        
         # Reshaping the outputs
         y = y.reshape(
             x_batch.size(0), input_fc)
@@ -145,4 +155,5 @@ for e in range(fine_tune_epochs):
 torch.save(model, "tuned_model.pth")
 
 # Checking the model's history
-print(model.history)
+for m in model.models:
+    print(m.history)

--- a/examples/applications/deep/conv_dbn_classification.py
+++ b/examples/applications/deep/conv_dbn_classification.py
@@ -32,7 +32,8 @@ model = ConvDBN(
     learning_rate=(0.0001, 0.00001),
     momentum=(0, 0),
     decay=(0, 0),
-    maxpooling=(False, True),
+    maxpooling=(True, False),
+    #pooling_kernel=(2, 0), # WORKING ON ...
     use_gpu=True,
 )
 
@@ -55,8 +56,9 @@ h1 = model.models[len(model.models)-1].hidden_shape[0]
 h2 = model.models[len(model.models)-1].hidden_shape[1]
 nf = model.models[len(model.models)-1].n_filters
 
-if model.models[len(model.models)-1].maxpooling:
+if model.models[len(model.models)-1].maxpooling:    
     input_fc = nf * (h1//2 + 1) * (h2//2 + 1)
+    print('pooling', input_fc)
 else:
     input_fc = nf * h1 * h2
 fc = nn.Linear(input_fc , n_classes)

--- a/examples/applications/deep/conv_dbn_training.py
+++ b/examples/applications/deep/conv_dbn_training.py
@@ -28,6 +28,7 @@ model = ConvDBN(
     learning_rate=(0.1, 0.1),
     momentum=(0, 0),
     decay=(0, 0),
+    maxpooling=True,
     use_gpu=True,
 )
 

--- a/examples/applications/gaussian/gaussian_conv_rbm_classification.py
+++ b/examples/applications/gaussian/gaussian_conv_rbm_classification.py
@@ -47,10 +47,14 @@ model = GaussianConvRBM(
 model.fit(train, batch_size=batch_size, epochs=5)
 
 # Creating the Fully Connected layer to append on top of RBM
+h1 = model.hidden_shape[0]
+h2 = model.hidden_shape[1]
+nf = model.n_filters
+
 if model.maxpooling:
-    input_fc = n_filters * (model.hidden_shape[0] * model.hidden_shape[1])//2
+    input_fc = nf * (h1//2 + 1) * (h2//2 + 1)
 else:
-    input_fc = n_filters * model.hidden_shape[0] * model.hidden_shape[1]
+    input_fc = nf * h1 * h2
 fc = nn.Linear(input_fc , n_classes)
 
 # Check if model uses GPU

--- a/learnergy/core/dataset.py
+++ b/learnergy/core/dataset.py
@@ -2,6 +2,7 @@
 """
 
 from typing import Optional, Tuple
+from xmlrpc.client import Boolean
 
 import numpy as np
 import torch
@@ -16,7 +17,8 @@ class Dataset(torch.utils.data.Dataset):
     """A custom dataset class, inherited from PyTorch's dataset."""
 
     def __init__(
-        self, data: np.array, targets: np.array, transform: Optional[callable] = None
+        self, data: np.array, targets: np.array, 
+        transform: Optional[callable] = None, show_log: Optional[Boolean] = True
     ) -> None:
         """Initialization method.
 
@@ -27,19 +29,19 @@ class Dataset(torch.utils.data.Dataset):
 
         """
 
-        logger.info("Creating class: Dataset.")
-
         self.data = data
         self.targets = targets
         self.transform = transform
 
-        logger.info("Class created.")
-        logger.debug(
-            "Data: %s | Targets: %s | Transforms: %s.",
-            self.data.shape,
-            self.targets.shape,
-            self.transform,
-        )
+        if show_log:
+            logger.info("Creating class: Dataset.")
+            logger.info("Class created.")
+            logger.debug(
+                "Data: %s | Targets: %s | Transforms: %s.",
+                self.data.shape,
+                self.targets.shape,
+                self.transform,
+            )
 
     @property
     def data(self) -> np.array:

--- a/learnergy/models/bernoulli/conv_rbm.py
+++ b/learnergy/models/bernoulli/conv_rbm.py
@@ -40,6 +40,7 @@ class ConvRBM(Model):
         momentum: Optional[float] = 0.0,
         decay: Optional[float] = 0.0,
         maxpooling: Optional[bool] = False,
+        pooling_kernel: Optional[int] = 2,
         use_gpu: Optional[bool] = False,
     ) -> None:
         """Initialization method.
@@ -53,7 +54,8 @@ class ConvRBM(Model):
             learning_rate: Learning rate.
             momentum: Momentum parameter.
             decay: Weight decay used for penalization.
-            maxpooling: Whether MaxPooling should be applied or not.
+            maxpooling: Whether MaxPooling2D should be used or not.
+            pooling_kernel: The kernel size of MaxPooling layer (when maxpooling=True).
             use_gpu: Whether GPU should be used or not.
 
         """
@@ -78,7 +80,7 @@ class ConvRBM(Model):
         self.decay = decay
 
         if maxpooling:
-            self.maxpol2d = nn.MaxPool2d(kernel_size=2, stride=2, padding=1)
+            self.maxpol2d = nn.MaxPool2d(kernel_size=pooling_kernel, stride=2, padding=1)
             self.maxpooling = True
         else:
             self.maxpol2d = maxpooling
@@ -102,7 +104,7 @@ class ConvRBM(Model):
             "Visible: %s | Filters: %d x %s | Hidden: %s | "
             "Channels: %d | Learning: CD-%d | "
             "Hyperparameters: lr = %s, momentum = %s, decay = %s | "
-            "Pooling: MaxPooling2D: %s.",
+            "Pooling: MaxPooling2D = %s: (%s, %s).",
             self.visible_shape,
             self.n_filters,
             self.filter_shape,
@@ -113,6 +115,7 @@ class ConvRBM(Model):
             self.momentum,
             self.decay,
             self.maxpooling,
+            pooling_kernel, pooling_kernel,
         )
 
     @property

--- a/learnergy/models/bernoulli/conv_rbm.py
+++ b/learnergy/models/bernoulli/conv_rbm.py
@@ -76,6 +76,7 @@ class ConvRBM(Model):
         self.lr = learning_rate
         self.momentum = momentum
         self.decay = decay
+
         if maxpooling:
             self.maxpol2d = nn.MaxPool2d(kernel_size=2, stride=2, padding=1)
             self.maxpooling = True
@@ -226,6 +227,19 @@ class ConvRBM(Model):
             raise e.ValueError("`decay` should be >= 0")
 
         self._decay = decay
+
+    @property
+    def maxpooling(self) -> bool:
+        """Usage of MaxPooling."""
+
+        return self._maxpooling
+
+    @maxpooling.setter
+    def maxpooling(self, maxpooling: bool) -> None:
+        if type(maxpooling) != bool:
+            raise e.ValueError("`maxpooling` should be True or False")
+
+        self._maxpooling = maxpooling
 
     @property
     def W(self) -> torch.nn.Parameter:

--- a/learnergy/models/bernoulli/conv_rbm.py
+++ b/learnergy/models/bernoulli/conv_rbm.py
@@ -39,6 +39,7 @@ class ConvRBM(Model):
         learning_rate: Optional[float] = 0.1,
         momentum: Optional[float] = 0.0,
         decay: Optional[float] = 0.0,
+        maxpooling: Optional[bool] = False,
         use_gpu: Optional[bool] = False,
     ) -> None:
         """Initialization method.
@@ -52,6 +53,7 @@ class ConvRBM(Model):
             learning_rate: Learning rate.
             momentum: Momentum parameter.
             decay: Weight decay used for penalization.
+            maxpooling: Whether MaxPooling should be applied or not.
             use_gpu: Whether GPU should be used or not.
 
         """
@@ -74,6 +76,12 @@ class ConvRBM(Model):
         self.lr = learning_rate
         self.momentum = momentum
         self.decay = decay
+        if maxpooling:
+            self.maxpol2d = nn.MaxPool2d(kernel_size=2, stride=2, padding=1)
+            self.maxpooling = True
+        else:
+            self.maxpol2d = maxpooling
+            self.maxpooling = False
 
         self.W = nn.Parameter(
             torch.randn(n_filters, n_channels, filter_shape[0], filter_shape[1]) * 0.01
@@ -92,7 +100,8 @@ class ConvRBM(Model):
         logger.debug(
             "Visible: %s | Filters: %d x %s | Hidden: %s | "
             "Channels: %d | Learning: CD-%d | "
-            "Hyperparameters: lr = %s, momentum = %s, decay = %s.",
+            "Hyperparameters: lr = %s, momentum = %s, decay = %s | "
+            "Pooling: MaxPooling2D: %s.",
             self.visible_shape,
             self.n_filters,
             self.filter_shape,
@@ -102,6 +111,7 @@ class ConvRBM(Model):
             self.lr,
             self.momentum,
             self.decay,
+            self.maxpooling,
         )
 
     @property
@@ -476,5 +486,7 @@ class ConvRBM(Model):
         """
 
         x, _ = self.hidden_sampling(x)
+        if self.maxpooling:
+            x = self.maxpol2d(x)
 
         return x

--- a/learnergy/models/deep/conv_dbn.py
+++ b/learnergy/models/deep/conv_dbn.py
@@ -242,6 +242,19 @@ class ConvDBN(Model):
         self._decay = decay
 
     @property
+    def maxpooling(self) -> Tuple[bool, ...]:
+        """Usage of MaxPooling."""
+
+        return self._maxpooling
+
+    @maxpooling.setter
+    def maxpooling(self, maxpooling: Tuple[bool, ...]) -> None:
+        if len(maxpooling) != self.n_layers:
+            raise e.ValueError("`maxpooling` should be a Tuple of True or False")
+
+        self._maxpooling = maxpooling
+
+    @property
     def models(self) -> List[torch.nn.Module]:
         """List of models (RBMs)."""
 
@@ -394,4 +407,5 @@ class ConvDBN(Model):
             if self.maxpooling[i]:
                 x = self.maxpol2d[i](x)
             i+=1
+
         return x

--- a/learnergy/models/gaussian/__init__.py
+++ b/learnergy/models/gaussian/__init__.py
@@ -1,7 +1,7 @@
 """A package contaning gaussian-valued models (networks) for all common learnergy modules.
 """
 
-from learnergy.models.gaussian.gaussian_conv_rbm import GaussianConvRBM
+from learnergy.models.gaussian.gaussian_conv_rbm import GaussianConvRBM, GaussianConvRBM4deep
 from learnergy.models.gaussian.gaussian_rbm import (
     GaussianRBM,
     GaussianReluRBM,

--- a/learnergy/models/gaussian/gaussian_conv_rbm.py
+++ b/learnergy/models/gaussian/gaussian_conv_rbm.py
@@ -38,6 +38,7 @@ class GaussianConvRBM(ConvRBM):
         learning_rate: Optional[float] = 0.1,
         momentum: Optional[float] = 0.0,
         decay: Optional[float] = 0.0,
+        maxpooling: Optional[bool] = False,
         use_gpu: Optional[bool] = False,
     ) -> None:
         """Initialization method.
@@ -66,10 +67,14 @@ class GaussianConvRBM(ConvRBM):
             learning_rate,
             momentum,
             decay,
+            maxpooling,
             use_gpu,
         )
 
         self.normalize = True
+
+        # Creating a Sigmoid function to employ on sampling
+        self.sig = torch.nn.Sigmoid()
 
         logger.info("Class overrided.")
 
@@ -116,7 +121,8 @@ class GaussianConvRBM(ConvRBM):
             # Uses the previously calculated activations
             probs = activations.detach()
         else:
-            probs = F.relu6(activations).detach()
+            #probs = F.relu6(activations).detach()
+            probs = self.sig(activations).detach()
 
         return probs, probs
 
@@ -147,7 +153,7 @@ class GaussianConvRBM(ConvRBM):
 
             start = time.time()
 
-            mse = 0
+            mse = 0            
 
             for samples, _ in tqdm(batches):
                 samples = samples.reshape(
@@ -188,5 +194,186 @@ class GaussianConvRBM(ConvRBM):
             self.dump(mse=mse.item(), time=end - start)
 
             logger.info("MSE: %f", mse)
+
+        return mse
+
+
+class GaussianConvRBM4deep(ConvRBM):
+    """A GaussianConvRBM class provides the basic implementation for
+    Gaussian-based Convolutional Restricted Boltzmann Machines.
+
+    References:
+        H. Lee, et al.
+        Convolutional deep belief networks for scalable unsupervised learning of hierarchical representations.
+        Proceedings of the 26th annual international conference on machine learning (2009).
+
+    """
+
+    def __init__(
+        self,
+        visible_shape: Optional[Tuple[int, int]] = (28, 28),
+        filter_shape: Optional[Tuple[int, int]] = (7, 7),
+        n_filters: Optional[int] = 5,
+        n_channels: Optional[int] = 1,
+        steps: Optional[int] = 1,
+        learning_rate: Optional[float] = 0.1,
+        momentum: Optional[float] = 0.0,
+        decay: Optional[float] = 0.0,
+        maxpooling: Optional[bool] = False,
+        use_gpu: Optional[bool] = False,
+    ) -> None:
+        """Initialization method.
+
+        Args:
+            visible_shape: Shape of visible units.
+            filter_shape: Shape of filters.
+            n_filters: Number of filters.
+            n_channels: Number of channels.
+            steps: Number of Gibbs' sampling steps.
+            learning_rate: Learning rate.
+            momentum: Momentum parameter.
+            decay: Weight decay used for penalization.
+            use_gpu: Whether GPU should be used or not.
+
+        """
+
+        logger.info("Overriding class: ConvRBM -> GaussianConvRBM.")
+
+        super(GaussianConvRBM4deep, self).__init__(
+            visible_shape,
+            filter_shape,
+            n_filters,
+            n_channels,
+            steps,
+            learning_rate,
+            momentum,
+            decay,
+            maxpooling,
+            use_gpu,
+        )
+
+        self.normalize = True
+
+        # Creating a Sigmoid function to employ on sampling
+        self.sig = torch.nn.Sigmoid()
+
+        logger.info("Class overrided.")
+
+    @property
+    def normalize(self) -> bool:
+        """Inner data normalization."""
+
+        return self._normalize
+
+    @normalize.setter
+    def normalize(self, normalize: bool) -> None:
+        self._normalize = normalize
+
+    def hidden_sampling(self, v: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Performs the hidden layer sampling, i.e., P(h|v).
+
+        Args:
+            v (torch.Tensor): A tensor incoming from the visible layer.
+
+        Returns:
+            (Tuple[torch.Tensor, torch.Tensor]): The probabilities and states of the hidden layer sampling.
+
+        """
+
+        activations = F.conv2d(v, self.W, bias=self.b)
+        probs = F.relu6(activations).detach()
+
+        return probs, probs
+
+    def visible_sampling(self, h: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Performs the visible layer sampling, i.e., P(v|h).
+
+        Args:
+            h: A tensor incoming from the hidden layer.
+
+        Returns:
+            (Tuple[torch.Tensor, torch.Tensor]): The probabilities and states of the visible layer sampling.
+
+        """
+
+        activations = F.conv_transpose2d(h, self.W, bias=self.a)
+
+        if self.normalize:
+            # Uses the previously calculated activations
+            probs = activations.detach()
+        else:
+            #probs = F.relu6(activations).detach()
+            probs = self.sig(activations).detach()
+
+        return probs, probs
+
+    def fit(
+        self,
+        dataset: torch.utils.data.Dataset,
+        batch_size: Optional[int] = 128,
+        epochs: Optional[int] = 10,
+    ) -> float:
+        """Fits a new GaussianConvRBM model.
+
+        Args:
+            dataset: A Dataset object containing the training data.
+            batch_size: Amount of samples per batch.
+            epochs: Number of training epochs.
+
+        Returns:
+            (float): MSE (mean squared error) from the training step.
+
+        """
+
+        batches = DataLoader(
+            dataset, batch_size=batch_size, shuffle=True, num_workers=0
+        )
+
+        for epoch in range(epochs):
+            #logger.info("Epoch %d/%d", epoch + 1, epochs)
+
+            start = time.time()
+
+            mse = 0            
+
+            for _, (samples, _) in enumerate(batches):                
+                samples = samples.reshape(
+                    len(samples),
+                    self.n_channels,
+                    self.visible_shape[0],
+                    self.visible_shape[1],
+                )
+                if self.device == "cuda":
+                    samples = samples.cuda()
+
+                if self.normalize:
+                    samples = (samples - torch.mean(samples, 0, True)) / (
+                        torch.std(samples, 0, True) + c.EPSILON
+                    )
+
+                # Performs the Gibbs sampling procedure
+                _, _, _, _, visible_states = self.gibbs_sampling(samples)
+                visible_states = visible_states.detach()
+
+                cost = torch.mean(self.energy(samples)) - torch.mean(
+                    self.energy(visible_states)
+                )
+
+                self.optimizer.zero_grad()
+                cost.backward()
+                self.optimizer.step()
+
+                batch_mse = torch.div(
+                    torch.sum(torch.pow(samples - visible_states, 2)), batch_size
+                ).detach()
+                mse += batch_mse
+
+            mse /= len(batches)
+
+            end = time.time()
+
+            self.dump(mse=mse.item(), time=end - start)
+
+            #logger.info("MSE: %f", mse)
 
         return mse

--- a/learnergy/models/gaussian/gaussian_conv_rbm.py
+++ b/learnergy/models/gaussian/gaussian_conv_rbm.py
@@ -39,6 +39,7 @@ class GaussianConvRBM(ConvRBM):
         momentum: Optional[float] = 0.0,
         decay: Optional[float] = 0.0,
         maxpooling: Optional[bool] = False,
+        pooling_kernel: Optional[int] = 2,
         use_gpu: Optional[bool] = False,
     ) -> None:
         """Initialization method.
@@ -68,6 +69,7 @@ class GaussianConvRBM(ConvRBM):
             momentum,
             decay,
             maxpooling,
+            pooling_kernel,
             use_gpu,
         )
 
@@ -220,6 +222,7 @@ class GaussianConvRBM4deep(ConvRBM):
         momentum: Optional[float] = 0.0,
         decay: Optional[float] = 0.0,
         maxpooling: Optional[bool] = False,
+        pooling_kernel: Optional[int] = 2,
         use_gpu: Optional[bool] = False,
     ) -> None:
         """Initialization method.
@@ -249,6 +252,7 @@ class GaussianConvRBM4deep(ConvRBM):
             momentum,
             decay,
             maxpooling,
+            pooling_kernel,
             use_gpu,
         )
 


### PR DESCRIPTION
Updating our convolutional (shallow and deep) models with MaxPooling2D, and an optimized way to train deeper models (DBNs), to avoid an entire dataset transformation through the model (hidden sampling to subsequent RBMs visible layer).
As an optional parameter of usage (maxpooling), usually, it is disabled (False), and its kernel size is equal to 2. Additionally, I added a parameter named pooling_kernel, in which (in the future) we will change the kernel size of the pooling layer.
**When kernel size is different from 2, some crashes may occur** since the code is not complete. It needs some adjustments regarding the hidden layers' visible shape to match the output from the previous layer when MaxPooling2D is applied.