### PR TITLE
*DBN 'models' attribute update

### DIFF
--- a/learnergy/models/deep/conv_dbn.py
+++ b/learnergy/models/deep/conv_dbn.py
@@ -93,7 +93,7 @@ class ConvDBN(Model):
             else:
                 self.maxpol2d.append(None)
 
-        self.models = []
+        self.models = nn.ModuleList([])
         for i in range(self.n_layers):
             if i == 0 and model=='gaussian' :
                 m = MODELS[model](

--- a/learnergy/models/deep/dbn.py
+++ b/learnergy/models/deep/dbn.py
@@ -5,6 +5,8 @@ from typing import List, Optional, Tuple, Union
 
 import torch
 from torch.utils.data import DataLoader
+import torch.nn as nn
+
 from tqdm import tqdm
 
 import learnergy.utils.exception as e
@@ -99,7 +101,7 @@ class DBN(Model):
             for _ in range(len(model) - 1, self.n_layers):
                 model += ("sigmoid4deep",)
 
-        self.models = []
+        self.models = nn.ModuleList([])
         for i in range(self.n_layers):
             if i == 0:
                 n_input = self.n_visible

--- a/tests/learnergy/models/deep/test_conv_dbn.py
+++ b/tests/learnergy/models/deep/test_conv_dbn.py
@@ -1,4 +1,5 @@
 import torch
+import torch.nn as nn
 import torchvision
 
 from learnergy.models.deep import conv_dbn
@@ -205,6 +206,6 @@ def test_dbn_models():
 def test_dbn_models_setter():
     new_dbn = conv_dbn.ConvDBN()
 
-    new_dbn.models = []
+    new_dbn.models = nn.ModuleList()
 
     assert len(new_dbn.models) == 0

--- a/tests/learnergy/models/deep/test_dbn.py
+++ b/tests/learnergy/models/deep/test_dbn.py
@@ -1,4 +1,5 @@
 import torch
+import torch.nn as nn
 import torchvision
 
 from learnergy.models.deep import dbn
@@ -198,7 +199,7 @@ def test_dbn_models():
 def test_dbn_models_setter():
     new_dbn = dbn.DBN()
 
-    new_dbn.models = []
+    new_dbn.models = nn.ModuleList()
 
     assert len(new_dbn.models) == 0
 


### PR DESCRIPTION
Changing DBN and ConvDBN `models` attribute to be of type torch.nn.ModuleList instead of a Python list. This allows for saving and loading of state dictionaries.